### PR TITLE
Fix template test in Emacs 25.

### DIFF
--- a/fillcode-test.el
+++ b/fillcode-test.el
@@ -433,8 +433,13 @@ foo(bar +
   (fillcode-test "template <class A, class B> qwert<A, B>;")
 
   ; ...but some whitespace around them should still be normalized
-  (fillcode-test "template <class   A> qwert< A >;"
-                 "template <class A> qwert< A >;")
+  ;; In Emacs 25, CC-Mode is smarter about angle brackets; it recognizes them
+  ;; as parentheses when they surround template arguments.  Therefore the test
+  ;; below now normalizes whitespace in <A>.  However, this only works in C++,
+  ;; and other languages don’t have such constructs anyway.
+  (fillcode-test-in-mode "template <class   A> qwert< A >;"
+                         "template <class A> qwert<A>;"
+                         'c++-mode)
   (fillcode-test "template <class A,   class B> qwert<A,B>;"
                  "template <class A, class B> qwert<A, B>;"))
 


### PR DESCRIPTION
Fixes #3

This breaks the test under Emacs 24, which I think is fine because
Emacs 25.1 is now officially released.