### PR TITLE
Improve fix for undefined symbols

### DIFF
--- a/fillcode.el
+++ b/fillcode.el
@@ -37,7 +37,10 @@
 (defconst fillcode-version "1.0.2")
 
 (require 'cc-bytecomp)  ;; for c-in-literal and c-literal-limits
+(require 'cc-cmds)
 (require 'cc-engine)
+(require 'cc-mode)
+(require 'python)
 
 ;; gnu emacs supports optional forms as the last arguments to
 ;; define-minor-mode; they're evaluated when the minor mode is enabled or
@@ -66,8 +69,6 @@ For more information, see https://snarfed.org/fillcode"
   (message "Using fillcode mode version %s" fillcode-version))
 
 (defvar fillcode-wrapped-fill-function)
-(defvar py-indent-offset)
-(defvar c-indent-offset)
 
 (defadvice fillcode-mode (after fillcode-mode-setup-and-teardown)
  ;; run these when fillcode-mode is enabled or disabled. the fillcode-mode var
@@ -675,7 +676,7 @@ return non-nil if we're past the first char of the start token, so
   "Returns the indent offset, ie the number of columns to indent, in the
 current mode."
   (if (eq major-mode 'python-mode)
-      py-indent-offset
+      python-indent-offset
     c-basic-offset))
 
 (defun fillcode-get-last-line-indent-offset ()


### PR DESCRIPTION
- Instead of forward-declaring, require the packages that define the symbols.

- python.el doesn’t define py-indent-offset, use python-indent-offset instead.

Fixes #9